### PR TITLE
logging: Enable logging output to also go to console

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -1,0 +1,6 @@
+---
+docker:
+  builds:
+    - path: .
+      dockerfile: Dockerfile
+      docker_repo: resin/resin-s3-minio

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/resin-base:v4.3.0
+FROM resin/resin-base:v4.4.0
 EXPOSE 80
 
 VOLUME /export

--- a/config/services/resin-s3.service
+++ b/config/services/resin-s3.service
@@ -2,6 +2,8 @@
 Description=resin-s3
 
 [Service]
+StandardOutput=journal+console
+StandardError=journal+console
 ExecStart=/go/bin/minio server --address ":80" /export
 
 [Install]


### PR DESCRIPTION
This change allows output to be captured by the Supervisor
on resinOS devices when run as a service.

Includes missing ResinCI config.

Connects-to: #16
Change-type: minor
Signed-off-by: Heds Simons <heds@resin.io>
---- Autogenerated Waffleboard Connection: Connects to #16