### PR TITLE
dns: Ensure DNS is prioritised over MDNS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM resin/resin-base:v4.4.0
+FROM resin/resin-base:v4.4.1
+
 EXPOSE 80
 
 VOLUME /export


### PR DESCRIPTION
Updates `resin-base` to ensure DNS is prioritised
over MDNS, ensuring `.local` aliases are resolved
before those published on the local subnet.

Connects-to: #18
Change-type: patch
Signed-off-by: Heds Simons <heds@resin.io>