### PR TITLE
config: Allow configurable credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ RUN curl -SLO https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.
     go get -u github.com/minio/minio
 
 # systemd and minio config
+RUN mkdir -p /root/.minio
+COPY config /usr/src/app/config
 COPY config/services/ /etc/systemd/system/
-COPY config/config.json /root/.minio/config.json
 
 # Enable Minio service
 RUN systemctl enable open-balena-s3.service

--- a/config/confd_env_backend/conf.d/config.json.toml
+++ b/config/confd_env_backend/conf.d/config.json.toml
@@ -1,0 +1,7 @@
+[template]
+src = "config.json.tmpl"
+dest = "/root/.minio/config.json"
+keys = [
+  "S3_MINIO_ACCESS_KEY",
+  "S3_MINIO_SECRET_KEY"
+]

--- a/config/confd_env_backend/templates/config.json.tmpl
+++ b/config/confd_env_backend/templates/config.json.tmpl
@@ -1,8 +1,8 @@
 {
 	"version": "9",
 	"credential": {
-		"accessKey": "abcdef1234",
-		"secretKey": "1234567890"
+		"accessKey": "{{getenv "S3_MINIO_ACCESS_KEY"}}",
+		"secretKey": "{{getenv "S3_MINIO_SECRET_KEY"}}"
 	},
 	"region": "us-east-1",
 	"logger": {

--- a/config/services/open-balena-s3.service
+++ b/config/services/open-balena-s3.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=open-balena-s3
+Requires=confd.service
+After=confd.service
 
 [Service]
 StandardOutput=journal+console


### PR DESCRIPTION
Ensures that the Minio access and secret keys can
be configured via a pair of envvars.

Connects-to: #27
Change-type: minor
Signed-off-by: Heds Simons <heds@balena.io>