### PR TITLE
config: Esure config file is stored in exports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -SLO https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.
     go get -u github.com/minio/minio
 
 # systemd and minio config
-RUN mkdir -p /root/.minio
+RUN mkdir -p /export/.minio.sys/config
 COPY config /usr/src/app/config
 COPY config/services/ /etc/systemd/system/
 

--- a/config/confd_env_backend/conf.d/config.json.toml
+++ b/config/confd_env_backend/conf.d/config.json.toml
@@ -1,6 +1,6 @@
 [template]
 src = "config.json.tmpl"
-dest = "/root/.minio/config.json"
+dest = "/export/.minio.sys/config/config.json"
 keys = [
   "S3_MINIO_ACCESS_KEY",
   "S3_MINIO_SECRET_KEY"

--- a/config/confd_env_backend/templates/config.json.tmpl
+++ b/config/confd_env_backend/templates/config.json.tmpl
@@ -1,5 +1,5 @@
 {
-	"version": "9",
+	"version": "33",
 	"credential": {
 		"accessKey": "{{getenv "S3_MINIO_ACCESS_KEY"}}",
 		"secretKey": "{{getenv "S3_MINIO_SECRET_KEY"}}"


### PR DESCRIPTION
With the new version of Minio, this change is required
to correctly pick up config credentials.

Connects-to: #38
Change-type: patch
Signed-off-by: Heds Simons <heds@balena.io>