### PR TITLE
feature: Create named buckets on start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,17 @@ RUN curl -SLO https://storage.googleapis.com/golang/go${GO_VERSION}.linux-amd64.
     GO111MODULE=on go get github.com/minio/minio && \
     rm -rf /go/pkg
 
+RUN wget -O /sbin/mc https://dl.min.io/client/mc/release/linux-amd64/mc && \
+    chmod +x /sbin/mc && \
+    mkdir -p /root/.mc
+
 # systemd and minio config
 COPY config /usr/src/app/config
 COPY config/services/ /etc/systemd/system/
+
+# create-buckets
+COPY scripts/create-buckets.sh /sbin/create-buckets.sh
+RUN systemctl enable create-buckets.service
 
 # Enable Minio service
 RUN systemctl enable open-balena-s3.service

--- a/config/confd_env_backend/conf.d/credentials.toml
+++ b/config/confd_env_backend/conf.d/credentials.toml
@@ -1,0 +1,7 @@
+[template]
+src = "credentials.tmpl"
+dest = "/root/.mc/config.json"
+keys = [
+  "S3_MINIO_ACCESS_KEY",
+  "S3_MINIO_SECRET_KEY"
+]

--- a/config/confd_env_backend/templates/credentials.tmpl
+++ b/config/confd_env_backend/templates/credentials.tmpl
@@ -1,0 +1,11 @@
+{
+    "version": "9",
+    "hosts": {
+        "localhost": {
+            "url": "http://127.0.0.1",
+            "accessKey": "{{getenv "S3_MINIO_ACCESS_KEY"}}",
+            "secretKey": "{{getenv "S3_MINIO_SECRET_KEY"}}",
+            "api": "S3v4"
+        }
+    }
+}

--- a/config/services/create-buckets.service
+++ b/config/services/create-buckets.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=bucket-init
+Requires=open-balena-s3.service
+After=open-balena-s3.service
+StartLimitIntervalSec=0
+
+[Service]
+StandardOutput=journal+console
+StandardError=journal+console
+EnvironmentFile=/etc/docker.env
+ExecStart=/sbin/create-buckets.sh
+Restart=on-failure
+
+[Install]
+WantedBy=basic.target

--- a/scripts/create-buckets.sh
+++ b/scripts/create-buckets.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "${BUCKETS}" ]; then
+    BUCKETS="${1:-}"
+fi
+
+# read the list of new buckets we wish to create...
+IFS=';' read -ra NEW_BUCKETS <<< "$BUCKETS"
+
+# pull the list of existing buckets...
+# - list the buckets in JSON
+# - extract the key value
+# - remove the last char, a slash in this case
+EXISTING_BUCKETS=($(mc ls --json localhost/ | jq .key -r | rev | cut -c 2- | rev))
+
+for bucket in "${NEW_BUCKETS[@]}"; do
+    echo "Create bucket: $bucket..."
+    if [[ ! " ${EXISTING_BUCKETS[@]} " =~ " ${bucket} " ]]; then
+        /sbin/mc mb "localhost/${bucket}"
+    else
+        echo "Bucket already exists: $bucket"
+    fi
+done


### PR DESCRIPTION
- pass a semi-colon seperated list of buckets to create after starting
- should be in the environment variable BUCKETS
- if it's empty/unset then do nothing

Change-type: patch
Signed-off-by: Rich Bayliss <rich@balena.io>